### PR TITLE
Direct the user to choose an issue template in edit links

### DIFF
--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -14,11 +14,11 @@
 {{ else if $gh_subdir }}
 {{ $editURL = printf "%s/edit/%s/%s/content/%s" $gh_repo $gh_branch $gh_subdir $pathFormatted }}
 {{ end }}
-{{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (htmlEscape $.Title )}}
+{{ $issuesURL := printf "%s/issues/new/choose?title=%s" $gh_repo (htmlEscape $.Title )}}
 <a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
 <a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
 {{ if $gh_project_repo }}
-{{ $project_issueURL := printf "%s/issues/new" $gh_project_repo }}
+{{ $project_issueURL := printf "%s/issues/new/choose" $gh_project_repo }}
 <a href="{{ $project_issueURL }}" target="_blank"><i class="fas fa-tasks fa-fw"></i> {{ T "post_create_project_issue" }}</a>
 {{ end }}
 </div>


### PR DESCRIPTION
Link to issues/new/choose, where the user can choose an issue template.

If the GitHub repo has no template, the user will be automatically redirected to issues/new.

See also: https://help.github.com/en/github/building-a-strong-community/using-templates-to-encourage-useful-issues-and-pull-requests

Example: https://github.com/cpeditor/cpeditor/issues/new/choose

It will be better if these links are configurable, but I'm not going to implement that.